### PR TITLE
fix: トップページの記事できてない表記を消去 (#53)

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -13,7 +13,6 @@ export const Home = () => (
       <LinkItem to="https://twitter.com/MctGakuseikai">学生会Twitter</LinkItem>
     </ul>
     <hr />
-    <p>ここに記事をおく予定 まだバックエンドできてないからごめん</p>
   </div>
 );
 


### PR DESCRIPTION
Close #53 